### PR TITLE
add install confirmation question

### DIFF
--- a/boot/olpc.fth
+++ b/boot/olpc.fth
@@ -3,7 +3,7 @@
 \ Full source at github.com/georgejhunt/HaitiOS
 
 visible
-.( -- Starting HaitiOS customization --    ) cr
+." -- HaitiOS 0.6.x --" cr
 
 \ step 0, stop if not an XO-1
 
@@ -30,64 +30,30 @@ then
 \ step 1, ensure firmware is updated
 
 ofw-version$ " Q2F19" $= 0= if
+   ." HaitiOS: reflashing firmware" cr
    " flash u:\boot\q2f19.rom" eval
    \ automatically reboots
 then
 
-\ step 2, ensure operating system is updated
-\ currently opting to have this be 4 button initiated
-\" copy-nand u:\21021o0.img" eval
+\ step 2, make sure user wants to destroy all data
 
-\ step 3, set the clock if it year < 2014 --removed
+." HaitiOS: press 'y' to erase this laptop and install HaitiOS: " cr
+begin  key  [char] y  =  until  .( y) cr
+
+\ step 3, install operating system
+\ " copy-nand u:\21021o0.img" eval
+." HaitiOS: installed, customizing ..." cr
+
 \ step 4, boot Tiny Core Linux and run xo-custom
 
-.( -- Tiny Core Linux boot script for Open Firmware    ) cr
-.(    by quozl@laptop.org, 2013-07-30               -- ) cr cr
-
-\ translate a bundle suffix string to an architecture tag string
-: b>a  ( bundle$ -- architecture$ )
-   drop c@ case
-      [char] 0  of  " x86" exit  endof
-      [char] 1  of  " x86" exit  endof
-      [char] 2  of  " arm" exit  endof
-      [char] 4  of  " arm" exit  endof
-   endcase
-;
-
-\ translate a bundle suffix string to an serial terminal tag string
-: b>s  ( bundle$ -- serialterm$ )
-   drop c@ case
-      [char] 0  of  " ttyS0" exit  endof
-      [char] 1  of  " ttyS0" exit  endof
-      [char] 2  of  " ttyS2" exit  endof
-      [char] 4  of  " ttyS2" exit  endof
-   endcase
-;
-
-[ifndef] bundle-suffix$
-: bundle-suffix$
-   " model" " /" find-package drop get-package-property 2drop c@
-   case
-      [char] C  of  " 0" exit  endof
-      [char] D  of  " 1" exit  endof
-      " 2" exit
-   endcase
-;
-[then]
-
-\ set macros
-bundle-suffix$     " MACHINE"      $set-macro
-bundle-suffix$ b>a " ARCHITECTURE" $set-macro
-bundle-suffix$ b>s " SERIALTERM"   $set-macro
-
 \ set kernel command line
-" fbcon=font:SUN12x22 superuser quiet showapps multivt waitusb=5 nozswap console=${SERIALTERM},115200 console=tty0 xo-custom"                           expand$ to boot-file
+" fbcon=font:SUN12x22 superuser quiet showapps multivt waitusb=5 nozswap console=ttyS0,115200 console=tty0 xo-custom" to boot-file
 
 \ choose initramfs
-" last:\boot\initrd.${ARCHITECTURE}"   expand$ to ramdisk
+" last:\boot\initrd.x86" to ramdisk
 
 \ choose kernel
-" last:\boot\vmlinuz.${MACHINE}"       expand$ to boot-device
+" last:\boot\vmlinuz.0" to boot-device
 
 cr
 boot


### PR DESCRIPTION
- ask the user whether to install, after the firmware upgrade,
- print snappy messages,
- correctly comment out the copy-nand step,
- remove the lengthy Tiny Core Linux compatibility code required for
  XO-1.5, XO-1.75, and XO-4.
